### PR TITLE
Multitenancy, Purge, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ You have multiple options for setting up your SQL database:
 
 If setting up your SQL database manually or in Azure, make sure to select the `Latin1_General_100_BIN2_UTF8` collation. This setting might be hidden away in the "Additional settings" section of your chosen setup flow. This is taken care of for you if you use the Docker setup script mentioned previously.
 
+If you are setting up your SQL database on a locally installed version of SQL Server on Windows (not using a container image) AND if you plan on running the automated tests, then you will need to [enable SQL Server and Windows Authentication mode](https://docs.microsoft.com/sql/database-engine/configure-windows/change-server-authentication-mode).
+
+### Multitenancy
+
+Starting in v0.3.0, this provider supports [multitenancy](https://en.wikipedia.org/wiki/Multitenancy) in a single database. This is useful if you plan to host a single database that supports multiple teams in your organization. To enable multitenancy, each tenant must be given its own login and user ID for the target database. To ensure that each tenant can only access its own data, you should add each user to the `dt_runtime` role that is created automatically by the setup scripts using the following T-SQL syntax.
+
+```sql
+ALTER ROLE dt_runtime ADD MEMBER {username}
+```
+
+Each tenant should then use a SQL connection string with login credentials for their assigned user account. See [this SQL Server documentation](https://docs.microsoft.co/sql/relational-databases/security/authentication-access/create-a-database-user) for details on how to create and manage database users.
+
 ### Azure Functions-hosted
 
 For local development using Azure Functions, select one of the [tools available for local development](https://docs.microsoft.com/azure/azure-functions/functions-develop-local). To configure the SQL provider, you'll need to add the following NuGet package reference to your .csproj file.

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -17,7 +17,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).2.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).3.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -18,7 +18,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).2.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).3.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>

--- a/src/DurableTask.SqlServer/LogHelper.cs
+++ b/src/DurableTask.SqlServer/LogHelper.cs
@@ -55,12 +55,23 @@
             this.WriteLog(logEvent);
         }
 
-        public void CheckpointingOrchestration(OrchestrationState state)
+        public void CheckpointStarting(OrchestrationState state)
         {
-            var logEvent = new LogEvents.CheckpointingOrchestrationEvent(
+            var logEvent = new LogEvents.CheckpointStartingEvent(
                 state.Name,
                 state.OrchestrationInstance,
                 state.OrchestrationStatus);
+
+            this.WriteLog(logEvent);
+        }
+
+
+        public void CheckpointCompleted(OrchestrationState state, Stopwatch latencyStopwatch)
+        {
+            var logEvent = new LogEvents.CheckpointCompletedEvent(
+                state.Name,
+                state.OrchestrationInstance,
+                latencyStopwatch.ElapsedMilliseconds);
 
             this.WriteLog(logEvent);
         }

--- a/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
+++ b/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
@@ -82,8 +82,8 @@
             }
         }
 
-        [Event(EventIds.CheckpointingOrchestration, Level = EventLevel.Informational)]
-        public void CheckpointingOrchestration(
+        [Event(EventIds.CheckpointStarting, Level = EventLevel.Informational)]
+        public void CheckpointStarting(
             string Name,
             string InstanceId,
             string ExecutionId,
@@ -93,11 +93,31 @@
         {
             // TODO: Switch to WriteEventCore for better performance
             this.WriteEvent(
-                EventIds.CheckpointingOrchestration,
+                EventIds.CheckpointStarting,
                 Name,
                 InstanceId,
                 ExecutionId,
                 Status,
+                AppName,
+                ExtensionVersion);
+        }
+
+        [Event(EventIds.CheckpointCompleted, Level = EventLevel.Informational)]
+        public void CheckpointCompleted(
+            string Name,
+            string InstanceId,
+            string ExecutionId,
+            long LatencyMs,
+            string AppName,
+            string ExtensionVersion)
+        {
+            // TODO: Switch to WriteEventCore for better performance
+            this.WriteEvent(
+                EventIds.CheckpointCompleted,
+                Name,
+                InstanceId,
+                ExecutionId,
+                LatencyMs,
                 AppName,
                 ExtensionVersion);
         }

--- a/src/DurableTask.SqlServer/Logging/EventIds.cs
+++ b/src/DurableTask.SqlServer/Logging/EventIds.cs
@@ -11,6 +11,7 @@
         public const int SprocCompleted = 302;
         public const int ProcessingFailure = 303;
         public const int GenericWarning = 304;
-        public const int CheckpointingOrchestration = 306;
+        public const int CheckpointStarting = 305;
+        public const int CheckpointCompleted = 306;
     }
 }

--- a/src/DurableTask.SqlServer/Logging/LogEvents.cs
+++ b/src/DurableTask.SqlServer/Logging/LogEvents.cs
@@ -127,7 +127,7 @@
             public override LogLevel Level => LogLevel.Error;
 
             protected override string CreateLogMessage() =>
-                $"An error occurred while processing a work-item for instance '{this.InstanceId}': {this.Details}";
+                $"{this.InstanceId}: An error occurred while processing a work-item: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 DefaultEventSource.Log.ProcessingError(
@@ -172,9 +172,9 @@
                     DTUtils.ExtensionVersionString);
         }
 
-        internal class CheckpointingOrchestrationEvent : StructuredLogEvent, IEventSourceEvent
+        internal class CheckpointStartingEvent : StructuredLogEvent, IEventSourceEvent
         {
-            public CheckpointingOrchestrationEvent(
+            public CheckpointStartingEvent(
                 string name,
                 OrchestrationInstance instance,
                 OrchestrationStatus status)
@@ -198,20 +198,64 @@
             public string Status { get; }
 
             public override EventId EventId => new EventId(
-                EventIds.CheckpointingOrchestration,
-                nameof(EventIds.CheckpointingOrchestration));
+                EventIds.CheckpointStarting,
+                nameof(EventIds.CheckpointStarting));
 
             public override LogLevel Level => LogLevel.Information;
 
             protected override string CreateLogMessage() =>
-                $"Checkpointing orchestration '{this.Name}' with ID {this.InstanceId} and status: {this.Status}";
+                $"{this.InstanceId}: Checkpointing orchestration '{this.Name}' with status: {this.Status}";
 
             void IEventSourceEvent.WriteEventSource() =>
-                DefaultEventSource.Log.CheckpointingOrchestration(
+                DefaultEventSource.Log.CheckpointStarting(
                     this.Name,
                     this.InstanceId,
                     this.ExecutionId,
                     this.Status,
+                    DTUtils.AppName,
+                    DTUtils.ExtensionVersionString);
+        }
+
+        internal class CheckpointCompletedEvent : StructuredLogEvent, IEventSourceEvent
+        {
+            public CheckpointCompletedEvent(
+                string name,
+                OrchestrationInstance instance,
+                long latencyMs)
+            {
+                this.Name = name;
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId ?? string.Empty;
+                this.LatencyMs = latencyMs;
+            }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.CheckpointCompleted,
+                nameof(EventIds.CheckpointCompleted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Checkpoint of '{this.Name}' completed. Latency: {this.LatencyMs}ms";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                DefaultEventSource.Log.CheckpointCompleted(
+                    this.Name,
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.LatencyMs,
                     DTUtils.AppName,
                     DTUtils.ExtensionVersionString);
         }

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -10,6 +10,7 @@ DROP PROCEDURE IF EXISTS dt.CreateInstance
 DROP PROCEDURE IF EXISTS dt.QuerySingleOrchestration
 DROP PROCEDURE IF EXISTS dt.RaiseEvent
 DROP PROCEDURE IF EXISTS dt.TerminateInstance
+DROP PROCEDURE IF EXISTS dt.PurgeInstanceState
 
 -- Private sprocs
 DROP PROCEDURE IF EXISTS dt._AddOrchestrationEvents

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -35,5 +35,8 @@ DROP TYPE IF EXISTS dt.HistoryEvents
 DROP TYPE IF EXISTS dt.OrchestrationEvents
 DROP TYPE IF EXISTS dt.TaskEvents
 
--- This must be the last DROP statement
+-- This must be the last DROP statement related to schema
 DROP SCHEMA IF EXISTS dt
+
+-- Roles
+DROP ROLE IF EXISTS dt_runtime

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -38,5 +38,17 @@ DROP TYPE IF EXISTS dt.TaskEvents
 -- This must be the last DROP statement related to schema
 DROP SCHEMA IF EXISTS dt
 
--- Roles
+-- Roles: all members have to be dropped before the role can be dropped
+DECLARE @rolename sysname = 'dt_runtime';
+DECLARE @cmd AS nvarchar(MAX) = N'';
+SELECT @cmd = @cmd + '
+    ALTER ROLE ' + QUOTENAME(@rolename) + ' DROP MEMBER ' + QUOTENAME(members.[name]) + ';'
+FROM sys.database_role_members AS rolemembers
+    JOIN sys.database_principals AS roles 
+        ON roles.[principal_id] = rolemembers.[role_principal_id]
+    JOIN sys.database_principals AS members 
+        ON members.[principal_id] = rolemembers.[member_principal_id]
+WHERE roles.[name] = @rolename
+EXEC(@cmd);
+
 DROP ROLE IF EXISTS dt_runtime

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -258,6 +258,50 @@ END
 GO
 
 
+CREATE OR ALTER PROCEDURE dt.PurgeInstanceState
+    @ThresholdTime datetime2,
+    @FilterType tinyint = 0
+AS
+BEGIN
+    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+
+    DECLARE @InstanceIDs TABLE (InstanceID varchar(100))
+
+    IF @FilterType = 0 -- created time
+    BEGIN
+        INSERT INTO @InstanceIDs
+            SELECT [InstanceID] FROM Instances
+            WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
+                AND [CreatedTime] >= @ThresholdTime
+    END
+    ELSE IF @FilterType = 1 -- completed time
+    BEGIN
+        INSERT INTO @InstanceIDs
+            SELECT [InstanceID] FROM Instances
+            WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
+                AND [CompletedTime] >= @ThresholdTime
+    END
+    ELSE
+    BEGIN
+        DECLARE @msg nvarchar(100) = FORMATMESSAGE('Unknown or unsupported filter type: %d', @FilterType);
+        THROW 50000, @msg, 1;
+    END
+
+    BEGIN TRANSACTION
+
+    DELETE FROM NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    -- Other relevant tables are expected to be cleaned up via cascade deletes
+
+    COMMIT TRANSACTION
+
+    -- return the number of deleted instances
+    RETURN (SELECT COUNT(*) FROM @InstanceIDs)
+END
+GO
+
+
 CREATE OR ALTER PROCEDURE dt._LockNextOrchestration
     @BatchSize int,
     @LockedBy varchar(100),
@@ -510,7 +554,7 @@ BEGIN
     -- warning about missing messages
     DELETE E
     OUTPUT DELETED.InstanceID, DELETED.SequenceNumber
-    FROM dt.NewEvents E
+    FROM dt.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
         INNER JOIN @DeletedEvents D ON 
             D.InstanceID = E.InstanceID AND
             D.SequenceNumber = E.SequenceNumber AND

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -4,8 +4,15 @@
 AS
 BEGIN
     -- Implemented as a function to make it easier to customize
-    -- WARNING: Long usernames may be truncated
-    RETURN CONVERT(varchar(50), CURRENT_USER)
+    DECLARE @TaskHub varchar(50)
+    IF LEN(CURRENT_USER) <= 50
+        -- default behavior is to just use the username
+        SET @TaskHub = CONVERT(varchar(50), CURRENT_USER)
+    ELSE
+        -- if the username is too long, keep the first 16 characters and hash the rest
+        SET @TaskHub = CONVERT(varchar(16), CURRENT_USER) + '__' + CONVERT(varchar(32), HashBytes('MD5', CURRENT_USER), 2)
+
+    RETURN @TaskHub
 END
 GO
 

--- a/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
+++ b/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
@@ -123,12 +123,9 @@ BEGIN
         CONSTRAINT FK_Instances_CustomStatus_Payloads FOREIGN KEY (TaskHub, InstanceID, CustomStatusPayloadID) REFERENCES dt.Payloads(TaskHub, InstanceID, PayloadID)
 	)
 
-    -- This index is filtered to include only instances ready to be picked up for execution
-    CREATE INDEX IX_Instances_LockNext ON dt.Instances(TaskHub, RuntimeStatus)
-    INCLUDE ([LockExpiration])
-    WHERE [RuntimeStatus] IN ('Pending', 'Running')
-
-    -- TODO: Indexes to improve query search performance
+    -- This index is used by LockNext and Purge logic
+    CREATE INDEX IX_Instances_RuntimeStatus ON dt.Instances(TaskHub, RuntimeStatus)
+        INCLUDE ([LockExpiration], [CreatedTime], [CompletedTime])
 END
 
 IF OBJECT_ID(N'dt.NewEvents', 'U') IS NULL

--- a/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
+++ b/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
@@ -190,3 +190,17 @@ IF OBJECT_ID(N'dt.NewTasks', 'U') IS NULL
         CONSTRAINT FK_NewTasks_Payloads FOREIGN KEY (TaskHub, InstanceID, PayloadID) REFERENCES dt.Payloads(TaskHub, InstanceID, PayloadID)
     )
 GO
+
+-- Security 
+IF DATABASE_PRINCIPAL_ID('dt_runtime') IS NULL
+BEGIN
+    -- This is the role to which all low-priviledge user accounts should be associated using
+    -- the 'ALTER ROLE dt_runtime ADD MEMBER [<username>]' statement.
+    CREATE ROLE dt_runtime
+
+    -- This low-priviledge role will only have access to stored procedures in the dt schema.
+    -- Each stored procedure limits access to data based on the username, ensuring that no
+    -- database user can access data created by another database user.
+    GRANT EXECUTE ON SCHEMA::dt TO dt_runtime
+END
+GO

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -5,6 +5,7 @@
     using System.Data;
     using System.Data.Common;
     using System.Data.SqlTypes;
+    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -196,7 +197,8 @@
         {
             ExtendedOrchestrationWorkItem currentWorkItem = (ExtendedOrchestrationWorkItem)workItem;
 
-            this.traceHelper.CheckpointingOrchestration(orchestrationState);
+            this.traceHelper.CheckpointStarting(orchestrationState);
+            Stopwatch sw = Stopwatch.StartNew();
 
             using SqlConnection connection = await this.GetAndOpenConnectionAsync();
             using SqlCommand command = this.GetSprocCommand(connection, "dt._CheckpointOrchestration");
@@ -237,6 +239,8 @@
             {
                 this.orchestrationBackoffHelper.Reset();
             }
+
+            this.traceHelper.CheckpointCompleted(orchestrationState, sw);
         }
 
         public override Task AbandonTaskOrchestrationWorkItemAsync(TaskOrchestrationWorkItem workItem)

--- a/src/DurableTask.SqlServer/SqlProviderOptions.cs
+++ b/src/DurableTask.SqlServer/SqlProviderOptions.cs
@@ -22,11 +22,12 @@
 
         internal SqlConnection CreateConnection() => new SqlConnection(this.ConnectionString);
 
-        static string GetDefaultConnectionString()
+        internal static string GetDefaultConnectionString()
         {
             // The default for local development on a Windows OS
             string defaultConnectionString = "Server=localhost;Database=DurableDB;Trusted_Connection=True;";
 
+            // The use of SA_PASSWORD is intended for use with the mssql docker container
             string saPassword = Environment.GetEnvironmentVariable("SA_PASSWORD");
             if (string.IsNullOrEmpty(saPassword))
             {

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -191,12 +191,25 @@
 
         internal static SqlDateTime GetVisibleTime(HistoryEvent historyEvent)
         {
-            return historyEvent.EventType switch
+            DateTime dateTime;
+            switch (historyEvent.EventType)
             {
-                EventType.TimerCreated => ((TimerCreatedEvent)historyEvent).FireAt,
-                EventType.TimerFired => ((TimerFiredEvent)historyEvent).FireAt,
-                _ => SqlDateTime.Null,
-            };
+                case EventType.TimerCreated:
+                    dateTime = ((TimerCreatedEvent)historyEvent).FireAt;
+                    break;
+                case EventType.TimerFired:
+                    dateTime = ((TimerFiredEvent)historyEvent).FireAt;
+                    break;
+                default:
+                    return SqlDateTime.Null;
+            }
+
+            if (dateTime < SqlDateTime.MinValue.Value)
+            {
+                return SqlDateTime.MinValue;
+            }
+
+            return dateTime;
         }
 
         internal static SqlString GetRuntimeStatus(HistoryEvent historyEvent)

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -215,6 +215,7 @@
                 "dt.QuerySingleOrchestration",
                 "dt.RaiseEvent",
                 "dt.TerminateInstance",
+                "dt.PurgeInstanceState",
                 "dt._AddOrchestrationEvents",
                 "dt._CheckpointOrchestration",
                 "dt._CompleteTasks",

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -25,7 +25,7 @@
         Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
 
         [Fact]
-        public async Task EmptyOrchestration_Completes()
+        public async Task EmptyOrchestration()
         {
             string input = $"Hello {DateTime.UtcNow:o}";
             string orchestrationName = "EmptyOrchestration";
@@ -48,7 +48,7 @@
         }
 
         [Fact]
-        public async Task OrchestrationWithTimer_Completes()
+        public async Task SingleTimer()
         {
             string input = $"Hello {DateTime.UtcNow:o}";
             string orchestrationName = "OrchestrationWithTimer";
@@ -82,7 +82,7 @@
         }
 
         [Fact]
-        public async Task Orchestration_IsReplaying_Works()
+        public async Task IsReplaying()
         {
             TestInstance<string> instance = await this.testService.RunOrchestration<List<bool>, string>(
                 null,
@@ -107,7 +107,7 @@
         }
 
         [Fact]
-        public async Task OrchestrationWithActivity_Completes()
+        public async Task SingleActivity()
         {
             string input = $"[{DateTime.UtcNow:o}]";
 
@@ -127,7 +127,7 @@
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
-        public async Task OrchestrationsWithActivityChain_Completes(int parallelCount)
+        public async Task ActivityChain(int parallelCount)
         {
             List<TestInstance<string>> instances = await this.testService.RunOrchestrations<int, string>(
                 parallelCount,
@@ -155,7 +155,7 @@
         }
 
         [Fact]
-        public async Task OrchestrationWithException_Fails()
+        public async Task OrchestrationException()
         {
             string errorMessage = "Kah-BOOOOOM!!!";
 
@@ -172,7 +172,7 @@
         }
 
         [Fact]
-        public async Task OrchestrationWithActivityFailure_Fails()
+        public async Task ActivityException()
         {
             // Performs a delay and then returns the input
             TestInstance<string> instance = await this.testService.RunOrchestration(
@@ -189,7 +189,7 @@
         }
 
         [Fact]
-        public async Task OrchestrationWithActivityFanOut()
+        public async Task ActivityFanOut()
         {
             TestInstance<string> instance = await this.testService.RunOrchestration<string[], string>(
                 null,
@@ -218,7 +218,7 @@
         [Theory]
         [InlineData(1)]
         [InlineData(100)]
-        public async Task OrchestrationWithExternalEvents(int eventCount)
+        public async Task ExternalEvents(int eventCount)
         {
             TaskCompletionSource<int> tcs = null;
 
@@ -241,7 +241,7 @@
                 onEvent: (ctx, name, value) =>
                 {
                     Assert.Equal("Event" + value, name);
-                    tcs.SetResult(int.Parse(value));
+                    tcs.TrySetResult(int.Parse(value));
                 });
 
             for (int i = 0; i < eventCount; i++)
@@ -255,7 +255,7 @@
         }
 
         [Fact]
-        public async Task TerminateOrchestration()
+        public async Task Termination()
         {
             string input = $"Hello {DateTime.UtcNow:o}";
             string orchestrationName = "OrchestrationWithTimer";

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -2,60 +2,27 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
     using DurableTask.Core;
     using DurableTask.SqlServer.Tests.Logging;
-    using Microsoft.Extensions.Logging;
-    using Newtonsoft.Json;
+    using DurableTask.SqlServer.Tests.Utils;
     using Newtonsoft.Json.Linq;
     using Xunit;
     using Xunit.Abstractions;
 
     public class Orchestrations : IAsyncLifetime
     {
-        readonly SqlProviderOptions options;
-        readonly TestLogProvider logProvider;
-        readonly ILoggerFactory loggerFactory;
-
-        TaskHubWorker worker;
-        TaskHubClient client;
+        readonly TestService testService;
 
         public Orchestrations(ITestOutputHelper output)
         {
-            Type type = output.GetType();
-            FieldInfo testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
-            var test = (ITest)testMember.GetValue(output);
-            
-            this.logProvider = new TestLogProvider(output);
-            this.loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder.AddProvider(this.logProvider);
-            });
-
-            this.options = new SqlProviderOptions
-            {
-                AppName = test.DisplayName,
-                LoggerFactory = this.loggerFactory,
-            };
+            this.testService = new TestService(output);
         }
 
-        async Task IAsyncLifetime.InitializeAsync()
-        {
-            var provider = new SqlOrchestrationService(this.options);
-            await ((IOrchestrationService)provider).CreateIfNotExistsAsync();
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
 
-            this.worker = await new TaskHubWorker(provider, this.loggerFactory).StartAsync();
-            this.client = new TaskHubClient(provider, loggerFactory: this.loggerFactory);
-        }
-
-        async Task IAsyncLifetime.DisposeAsync()
-        {
-            await this.worker.StopAsync(isForced: true);
-            this.worker.Dispose();
-        }
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
 
         [Fact]
         public async Task EmptyOrchestration_Completes()
@@ -64,7 +31,7 @@
             string orchestrationName = "EmptyOrchestration";
 
             // Does nothing except return the original input
-            StartedInstance<string> instance = await this.RunOrchestration(
+            TestInstance<string> instance = await this.testService.RunOrchestration(
                 input,
                 orchestrationName,
                 implementation: (ctx, input) => Task.FromResult(input));
@@ -73,9 +40,9 @@
                 expectedOutput: input);
 
             // Validate logs
-            LogAssert.NoWarningsOrErrors(this.logProvider);
+            LogAssert.NoWarningsOrErrors(this.testService.LogProvider);
             LogAssert.Sequence(
-                this.logProvider,
+                this.testService.LogProvider,
                 LogAssert.AcquiredAppLock(),
                 LogAssert.CheckpointingOrchestration(orchestrationName));
         }
@@ -88,7 +55,7 @@
             TimeSpan delay = TimeSpan.FromSeconds(3);
 
             // Performs a delay and then returns the input
-            StartedInstance<string> instance = await this.RunOrchestration(
+            TestInstance<string> instance = await this.testService.RunOrchestration(
                 input,
                 orchestrationName,
                 implementation: async (ctx, input) =>
@@ -106,9 +73,9 @@
             Assert.True(state.CreatedTime.Add(delay) <= state.CompletedTime);
 
             // Validate logs
-            LogAssert.NoWarningsOrErrors(this.logProvider);
+            LogAssert.NoWarningsOrErrors(this.testService.LogProvider);
             LogAssert.Sequence(
-                this.logProvider,
+                this.testService.LogProvider,
                 LogAssert.AcquiredAppLock(),
                 LogAssert.CheckpointingOrchestration(orchestrationName),
                 LogAssert.CheckpointingOrchestration(orchestrationName));
@@ -117,7 +84,7 @@
         [Fact]
         public async Task Orchestration_IsReplaying_Works()
         {
-            StartedInstance<string> instance = await this.RunOrchestration<List<bool>, string>(
+            TestInstance<string> instance = await this.testService.RunOrchestration<List<bool>, string>(
                 null,
                 orchestrationName: "TwoTimerReplayTester",
                 implementation: async (ctx, _) =>
@@ -144,12 +111,12 @@
         {
             string input = $"[{DateTime.UtcNow:o}]";
 
-            StartedInstance<string> instance = await this.RunOrchestration(
+            TestInstance<string> instance = await this.testService.RunOrchestration(
                 input,
                 orchestrationName: "OrchestrationWithActivity",
                 implementation: (ctx, input) => ctx.ScheduleTask<string>("SayHello", "", input),
                 activities: new[] {
-                    ("SayHello", MakeActivity((TaskContext ctx, string input) => $"Hello, {input}!")),
+                    ("SayHello", TestService.MakeActivity((TaskContext ctx, string input) => $"Hello, {input}!")),
                 });
 
             OrchestrationState state = await instance.WaitForCompletion(
@@ -162,7 +129,7 @@
         [InlineData(100)]
         public async Task OrchestrationsWithActivityChain_Completes(int parallelCount)
         {
-            List<StartedInstance<string>> instances = await this.RunOrchestrations<int, string>(
+            List<TestInstance<string>> instances = await this.testService.RunOrchestrations<int, string>(
                 parallelCount,
                 _ => null,
                 orchestrationName: "OrchestrationsWithActivityChain",
@@ -177,7 +144,7 @@
                     return value;
                 },
                 activities: new[] {
-                    ("PlusOne", MakeActivity((TaskContext ctx, int input) => input + 1)),
+                    ("PlusOne", TestService.MakeActivity((TaskContext ctx, int input) => input + 1)),
                 });
 
             IEnumerable<Task> tasks = instances.Select(
@@ -193,7 +160,7 @@
             string errorMessage = "Kah-BOOOOOM!!!";
 
             // The exception is expected to fail the orchestration execution
-            StartedInstance<string> instance = await this.RunOrchestration<string, string>(
+            TestInstance<string> instance = await this.testService.RunOrchestration<string, string>(
                 null,
                 orchestrationName: "OrchestrationWithException",
                 implementation: (ctx, input) => throw new Exception(errorMessage));
@@ -208,12 +175,12 @@
         public async Task OrchestrationWithActivityFailure_Fails()
         {
             // Performs a delay and then returns the input
-            StartedInstance<string> instance = await this.RunOrchestration(
+            TestInstance<string> instance = await this.testService.RunOrchestration(
                 null as string,
                 orchestrationName: "OrchestrationWithActivityFailure",
                 implementation: (ctx, input) => ctx.ScheduleTask<string>("Throw", ""),
                 activities: new[] {
-                    ("Throw", MakeActivity<string, string>((ctx, input) => throw new Exception("Kah-BOOOOOM!!!"))),
+                    ("Throw", TestService.MakeActivity<string, string>((ctx, input) => throw new Exception("Kah-BOOOOOM!!!"))),
                 });
 
             OrchestrationState state = await instance.WaitForCompletion(
@@ -224,7 +191,7 @@
         [Fact]
         public async Task OrchestrationWithActivityFanOut()
         {
-            StartedInstance<string> instance = await this.RunOrchestration<string[], string>(
+            TestInstance<string> instance = await this.testService.RunOrchestration<string[], string>(
                 null,
                 orchestrationName: "OrchestrationWithActivityFanOut",
                 implementation: async (ctx, _) =>
@@ -241,7 +208,7 @@
                     return results;
                 },
                 activities: new[] {
-                    ("ToString", MakeActivity((TaskContext ctx, int input) => input.ToString())),
+                    ("ToString", TestService.MakeActivity((TaskContext ctx, int input) => input.ToString())),
                 });
 
             OrchestrationState state = await instance.WaitForCompletion(
@@ -255,7 +222,7 @@
         {
             TaskCompletionSource<int> tcs = null;
 
-            StartedInstance<string> instance = await this.RunOrchestration<int, string>(
+            TestInstance<string> instance = await this.testService.RunOrchestration<int, string>(
                 null,
                 orchestrationName: "OrchestrationWithExternalEvents",
                 implementation: async (ctx, _) =>
@@ -295,7 +262,7 @@
             TimeSpan delay = TimeSpan.FromSeconds(30);
 
             // Performs a delay and then returns the input
-            StartedInstance<string> instance = await this.RunOrchestration(
+            TestInstance<string> instance = await this.testService.RunOrchestration(
                 input,
                 orchestrationName,
                 implementation: (ctx, input) => ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), input));
@@ -313,9 +280,9 @@
                 expectedOutput: "Bye!");
 
             // Validate logs
-            LogAssert.NoWarningsOrErrors(this.logProvider);
+            LogAssert.NoWarningsOrErrors(this.testService.LogProvider);
             LogAssert.Sequence(
-                this.logProvider,
+                this.testService.LogProvider,
                 LogAssert.AcquiredAppLock(),
                 LogAssert.CheckpointingOrchestration(orchestrationName),
                 LogAssert.CheckpointingOrchestration(orchestrationName));
@@ -325,7 +292,7 @@
         [Fact]
         public async Task ContinueAsNew()
         {
-            StartedInstance<int> instance = await this.RunOrchestration(
+            TestInstance<int> instance = await this.testService.RunOrchestration(
                 input: 0,
                 orchestrationName: "ContinueAsNewTest",
                 implementation: async (ctx, input) =>
@@ -341,260 +308,6 @@
 
             TimeSpan timeout = TimeSpan.FromSeconds(5);
             await instance.WaitForCompletion(timeout, expectedOutput: 10, continuedAsNew: true);
-        }
-
-        async Task<List<StartedInstance<TInput>>> RunOrchestrations<TOutput, TInput>(
-            int count,
-            Func<int, TInput> inputGenerator,
-            string orchestrationName,
-            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
-            Action<OrchestrationContext, string, string> onEvent = null,
-            params (string name, TaskActivity activity)[] activities)
-        {
-            // Register the inline orchestration - note that this will only work once per test
-            Type orchestrationType = typeof(OrchestrationShim<TOutput, TInput>);
-
-            this.worker.AddTaskOrchestrations(new TestObjectCreator<TaskOrchestration>(
-                orchestrationName,
-                MakeOrchestration(implementation, onEvent)));
-
-            foreach ((string name, TaskActivity activity) in activities)
-            {
-                this.worker.AddTaskActivities(new TestObjectCreator<TaskActivity>(name, activity));
-            }
-
-            DateTime utcNow = DateTime.UtcNow;
-
-            var instances = new List<StartedInstance<TInput>>(count);
-            for (int i = 0; i < count; i++)
-            {
-                TInput input = inputGenerator(i);
-                OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(
-                    orchestrationName,
-                    string.Empty /* version */,
-                    input);
-
-                // Verify that the CreateOrchestrationInstanceAsync implementation set the InstanceID and ExecutionID fields
-                Assert.NotNull(instance.InstanceId);
-                Assert.NotNull(instance.ExecutionId);
-
-                instances.Add(new StartedInstance<TInput>(this.client, instance, utcNow, input));
-            }
-            
-            return instances;
-        }
-
-        async Task<StartedInstance<TInput>> RunOrchestration<TOutput, TInput>(
-            TInput input,
-            string orchestrationName,
-            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
-            Action<OrchestrationContext, string, string> onEvent = null,
-            params (string name, TaskActivity activity)[] activities)
-        {
-            var instances = await this.RunOrchestrations(
-                count: 1,
-                inputGenerator: i => input,
-                orchestrationName,
-                implementation,
-                onEvent,
-                activities);
-
-            return instances.First();
-        }
-
-        static TaskOrchestration MakeOrchestration<TOutput, TInput>(
-            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
-            Action<OrchestrationContext, string, string> onEvent = null)
-        {
-            return new OrchestrationShim<TOutput, TInput>(implementation, onEvent);
-        }
-
-        // This is just a wrapper around the constructor for convenience. It allows us to write 
-        // less code because generic arguments for methods can be implied, unlike constructors.
-        static TaskActivity MakeActivity<TInput, TOutput>(
-            Func<TaskContext, TInput, TOutput> implementation)
-        {
-            return new ActivityShim<TInput, TOutput>(implementation);
-        }
-
-        static string GetFriendlyTypeName(Type type)
-        {
-            string friendlyName = type.Name;
-            if (type.IsGenericType)
-            {
-                int iBacktick = friendlyName.IndexOf('`');
-                if (iBacktick > 0)
-                {
-                    friendlyName = friendlyName.Remove(iBacktick);
-                }
-
-                friendlyName += "<";
-                Type[] typeParameters = type.GetGenericArguments();
-                for (int i = 0; i < typeParameters.Length; ++i)
-                {
-                    string typeParamName = GetFriendlyTypeName(typeParameters[i]);
-                    friendlyName += (i == 0 ? typeParamName : "," + typeParamName);
-                }
-
-                friendlyName += ">";
-            }
-
-            return friendlyName;
-        }
-
-        class ActivityShim<TInput, TOutput> : TaskActivity<TInput, TOutput>
-        {
-            public ActivityShim(Func<TaskContext, TInput, TOutput> implementation)
-            {
-                this.Implementation = implementation;
-            }
-
-            public Func<TaskContext, TInput, TOutput> Implementation { get; }
-
-            protected override TOutput Execute(TaskContext context, TInput input)
-            {
-                return this.Implementation(context, input);
-            }
-        }
-
-        class OrchestrationShim<TOutput, TInput> : TaskOrchestration<TOutput, TInput>
-        {
-            public OrchestrationShim(
-                Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
-                Action<OrchestrationContext, string, string> onEvent = null)
-            {
-                this.Implementation = implementation;
-                this.OnEventRaised = onEvent;
-            }
-
-            public Func<OrchestrationContext, TInput, Task<TOutput>> Implementation { get; set; }
-
-            public Action<OrchestrationContext, string, string> OnEventRaised { get; set; }
-
-            public override Task<TOutput> RunTask(OrchestrationContext context, TInput input)
-                => this.Implementation(context, input);
-
-            public override void RaiseEvent(OrchestrationContext context, string name, string input)
-                => this.OnEventRaised(context, name, input);
-        }
-
-        class StartedInstance<T>
-        {
-            readonly TaskHubClient client;
-            readonly OrchestrationInstance instance;
-            readonly DateTime startTime;
-            readonly T input;
-
-            public StartedInstance(
-                TaskHubClient client,
-                OrchestrationInstance instance,
-                DateTime startTime,
-                T input)
-            {
-                this.client = client;
-                this.instance = instance;
-                this.startTime = startTime;
-                this.input = input;
-            }
-
-            OrchestrationInstance GetInstanceForAnyExecution() => new OrchestrationInstance
-            {
-                InstanceId = this.instance.InstanceId,
-            };
-
-            public async Task<OrchestrationState> WaitForCompletion(
-                TimeSpan timeout = default,
-                OrchestrationStatus expectedStatus = OrchestrationStatus.Completed,
-                object expectedOutput = null,
-                string expectedOutputRegex = null,
-                bool continuedAsNew = false)
-            {
-                if (timeout == default)
-                {
-                    timeout = TimeSpan.FromSeconds(5);
-                }
-
-                if (Debugger.IsAttached)
-                {
-                    timeout = timeout.Add(TimeSpan.FromMinutes(5));
-                }
-
-                OrchestrationState state = await this.client.WaitForOrchestrationAsync(this.GetInstanceForAnyExecution(), timeout);
-                Assert.NotNull(state);
-                Assert.Equal(expectedStatus, state.OrchestrationStatus);
-
-                if (this.input != null)
-                {
-                    Assert.Equal(JToken.FromObject(this.input), JToken.Parse(state.Input));
-                }
-                else
-                {
-                    Assert.Null(state.Input);
-                }
-
-                // For created time, account for potential clock skew
-                Assert.True(state.CreatedTime >= this.startTime.AddMinutes(-5));
-                Assert.True(state.LastUpdatedTime > state.CreatedTime);
-                Assert.True(state.CompletedTime > state.CreatedTime);
-                Assert.NotNull(state.OrchestrationInstance);
-                Assert.Equal(this.instance.InstanceId, state.OrchestrationInstance.InstanceId);
-
-                if (continuedAsNew)
-                {
-                    Assert.NotEqual(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
-                }
-                else
-                {
-                    Assert.Equal(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
-                }
-
-                if (expectedOutput != null)
-                {
-                    Assert.NotNull(state.Output);
-                    try
-                    {
-                        // DTFx usually encodes outputs as JSON values. The exception is error messages.
-                        // If this is an error message, we'll throw here and try the logic in the catch block.
-                        JToken.Parse(state.Output);
-                        Assert.Equal(JToken.FromObject(expectedOutput).ToString(Formatting.None), state.Output);
-                    }
-                    catch (JsonReaderException)
-                    {
-                        Assert.Equal(expectedOutput, state?.Output);
-                    }
-                }
-
-                if (expectedOutputRegex != null)
-                {
-                    Assert.Matches(expectedOutputRegex, state.Output);
-                }
-
-                return state;
-            }
-
-            internal Task RaiseEventAsync(string name, object value)
-            {
-                return this.client.RaiseEventAsync(this.instance, name, value);
-            }
-
-            internal Task TerminateAsync(string reason)
-            {
-                return this.client.TerminateInstanceAsync(this.instance, reason);
-            }
-        }
-
-        class TestObjectCreator<T> : ObjectCreator<T>
-        {
-            readonly T obj;
-
-            public TestObjectCreator(string name, T obj)
-            {
-                this.Name = name;
-                this.Version = string.Empty;
-                this.obj = obj;
-            }
-
-            public override T Create() => this.obj;
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
@@ -1,0 +1,117 @@
+﻿namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class PurgeTests : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public PurgeTests(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        /// <summary>
+        /// This test validates that the purge behavior works correctly based on runtime status and time.
+        /// </summary>
+        [Theory]
+        [InlineData(OrchestrationStateTimeRangeFilterType.OrchestrationCreatedTimeFilter)]
+        [InlineData(OrchestrationStateTimeRangeFilterType.OrchestrationCompletedTimeFilter)]
+        public async Task PurgesInstancesByStatus(OrchestrationStateTimeRangeFilterType filterType)
+        {
+            DateTime startTime = DateTime.UtcNow;
+
+            var events = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
+
+            // Waits for an external event and then either completes or fails depending on that event
+            List<TestInstance<string>> instances = await this.testService.RunOrchestrations(
+                count: 30, // ideally some multiple of 3
+                inputGenerator: i=> $"Hello, world {i}",
+                orchestrationName: "SimpleDelay",
+                implementation: async (ctx, input) =>
+                {
+                    var tcs = new TaskCompletionSource<bool>();
+                    events[ctx.OrchestrationInstance.InstanceId] = tcs;
+
+                    bool shouldFail = await tcs.Task;
+                    if (shouldFail)
+                    {
+                        throw new Exception("Kah-BOOOOOM!!!");
+                    }
+
+                    return shouldFail;
+                },
+                onEvent: (ctx, name, value) =>
+                {
+                    events[ctx.OrchestrationInstance.InstanceId].SetResult(bool.Parse(value));
+                });
+
+            await Task.WhenAll(instances.Select(instance => instance.WaitForStart()));
+
+            // Try to purge the instance and check that it still exists
+            await this.testService.PurgeAsync(startTime, filterType);
+            foreach (TestInstance<string> instance in instances)
+            {
+                OrchestrationState runningState = await instance.GetStateAsync();
+                Assert.Equal(OrchestrationStatus.Running, runningState.OrchestrationStatus);
+            }
+
+            TimeSpan timeout = TimeSpan.FromSeconds(30);
+
+            // We want to test a mix of completed, failed, and terminated instances to make sure they are all handled correctly.
+            var tasks = new List<Task>();
+            for (int i = 0; i < instances.Count; i++)
+            {
+                int index = i;
+                tasks.Add(Task.Run(async () =>
+                {
+                    TestInstance<string> instance = instances[index];
+                    if (index % 3 == 0)
+                    {
+                        // Complete the instance
+                        await instance.RaiseEventAsync("Action", false);
+                        await instance.WaitForCompletion(timeout, OrchestrationStatus.Completed);
+                    }
+                    else if (index % 3 == 1)
+                    {
+                        // Fail the instance
+                        await instance.RaiseEventAsync("Action", true);
+                        await instance.WaitForCompletion(timeout, OrchestrationStatus.Failed);
+                    }
+                    else
+                    {
+                        // Terminate the instance
+                        await instance.TerminateAsync("Terminated!");
+                        await instance.WaitForCompletion(timeout, OrchestrationStatus.Terminated);
+                    }
+                }));
+            }
+
+            // Wait for all instances to transition into their final state
+            await Task.WhenAll(tasks);
+
+            // This time-based purge should remove all the instances
+            await this.testService.PurgeAsync(startTime, filterType);
+            foreach (TestInstance<string> instance in instances)
+            {
+                OrchestrationState purgedState = await instance.GetStateAsync();
+                Assert.Null(purgedState);
+            }
+
+            // One more purge, just to make sure there are no failures when there is nothing left to purge
+            await this.testService.PurgeAsync(startTime, filterType);
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
+++ b/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
@@ -49,11 +49,11 @@
         public static LogAssert SchedulingLocalActivityEvent(string name) =>
             new LogAssert(304, "SchedulingLocalActivity", LogLevel.Information, name);
 
-        public static LogAssert StartingLocalActivity(string name) =>
-            new LogAssert(305, "StartingLocalActivity", LogLevel.Information, name);
+        public static LogAssert CheckpointStarting(string name) =>
+            new LogAssert(305, "CheckpointStarting", LogLevel.Information, name);
 
-        public static LogAssert CheckpointingOrchestration(string name) =>
-            new LogAssert(306, "CheckpointingOrchestration", LogLevel.Information, name);
+        public static LogAssert CheckpointCompleted(string name) =>
+            new LogAssert(306, "CheckpointCompleted", LogLevel.Information, name);
 
         public static void LogEntryCount(TestLogProvider logProvider, int expected) =>
             Assert.Equal(expected, GetLogs(logProvider).Count());
@@ -110,11 +110,17 @@
                     Assert.True(fields.ContainsKey("Name"));
                     Assert.True(fields.ContainsKey("LatencyMs"));
                     break;
-                case EventIds.CheckpointingOrchestration:
+                case EventIds.CheckpointStarting:
                     Assert.True(fields.ContainsKey("Name"));
                     Assert.True(fields.ContainsKey("InstanceId"));
                     Assert.True(fields.ContainsKey("ExecutionId"));
                     Assert.True(fields.ContainsKey("Status"));
+                    break;
+                case EventIds.CheckpointCompleted:
+                    Assert.True(fields.ContainsKey("Name"));
+                    Assert.True(fields.ContainsKey("InstanceId"));
+                    Assert.True(fields.ContainsKey("ExecutionId"));
+                    Assert.True(fields.ContainsKey("LatencyMs"));
                     break;
                 default:
                     throw new ArgumentException($"Log event {log.EventId} is not known. Does it need to be added to the log validator?", nameof(log));

--- a/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
@@ -133,7 +133,7 @@
         {
             if (timeout == default)
             {
-                timeout = TimeSpan.FromSeconds(5);
+                timeout = TimeSpan.FromSeconds(10);
             }
 
             if (Debugger.IsAttached)

--- a/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
@@ -1,0 +1,149 @@
+﻿namespace DurableTask.SqlServer.Tests.Utils
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    class TestInstance<T>
+    {
+        readonly TaskHubClient client;
+        readonly OrchestrationInstance instance;
+        readonly DateTime startTime;
+        readonly T input;
+
+        public TestInstance(
+            TaskHubClient client,
+            OrchestrationInstance instance,
+            DateTime startTime,
+            T input)
+        {
+            this.client = client;
+            this.instance = instance;
+            this.startTime = startTime;
+            this.input = input;
+        }
+
+        OrchestrationInstance GetInstanceForAnyExecution() => new OrchestrationInstance
+        {
+            InstanceId = this.instance.InstanceId,
+        };
+
+        public async Task<OrchestrationState> WaitForStart(TimeSpan timeout = default)
+        {
+            AdjustTimeout(ref timeout);
+
+            Stopwatch sw = Stopwatch.StartNew();
+            do
+            {
+                OrchestrationState state = await this.GetStateAsync();
+                if (state != null && state.OrchestrationStatus != OrchestrationStatus.Pending)
+                {
+                    return state;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+            } while (sw.Elapsed < timeout);
+
+            throw new TimeoutException($"Orchestration with instance ID '{this.instance.InstanceId}' failed to start.");
+        }
+
+        public async Task<OrchestrationState> WaitForCompletion(
+            TimeSpan timeout = default,
+            OrchestrationStatus expectedStatus = OrchestrationStatus.Completed,
+            object expectedOutput = null,
+            string expectedOutputRegex = null,
+            bool continuedAsNew = false)
+        {
+            AdjustTimeout(ref timeout);
+
+            OrchestrationState state = await this.client.WaitForOrchestrationAsync(this.GetInstanceForAnyExecution(), timeout);
+            Assert.NotNull(state);
+            Assert.Equal(expectedStatus, state.OrchestrationStatus);
+
+            if (this.input != null)
+            {
+                Assert.Equal(JToken.FromObject(this.input), JToken.Parse(state.Input));
+            }
+            else
+            {
+                Assert.Null(state.Input);
+            }
+
+            // For created time, account for potential clock skew
+            Assert.True(state.CreatedTime >= this.startTime.AddMinutes(-5));
+            Assert.True(state.LastUpdatedTime > state.CreatedTime);
+            Assert.True(state.CompletedTime > state.CreatedTime);
+            Assert.NotNull(state.OrchestrationInstance);
+            Assert.Equal(this.instance.InstanceId, state.OrchestrationInstance.InstanceId);
+
+            if (continuedAsNew)
+            {
+                Assert.NotEqual(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
+            }
+            else
+            {
+                Assert.Equal(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
+            }
+
+            if (expectedOutput != null)
+            {
+                Assert.NotNull(state.Output);
+                try
+                {
+                    // DTFx usually encodes outputs as JSON values. The exception is error messages.
+                    // If this is an error message, we'll throw here and try the logic in the catch block.
+                    JToken.Parse(state.Output);
+                    Assert.Equal(JToken.FromObject(expectedOutput).ToString(Formatting.None), state.Output);
+                }
+                catch (JsonReaderException)
+                {
+                    Assert.Equal(expectedOutput, state?.Output);
+                }
+            }
+
+            if (expectedOutputRegex != null)
+            {
+                Assert.Matches(expectedOutputRegex, state.Output);
+            }
+
+            return state;
+        }
+
+        internal Task<OrchestrationState> GetStateAsync()
+        {
+            return this.client.GetOrchestrationStateAsync(this.instance);
+        }
+
+        internal Task RaiseEventAsync(string name, object value)
+        {
+            return this.client.RaiseEventAsync(this.instance, name, value);
+        }
+
+        internal Task TerminateAsync(string reason)
+        {
+            return this.client.TerminateInstanceAsync(this.instance, reason);
+        }
+
+        static void AdjustTimeout(ref TimeSpan timeout)
+        {
+            if (timeout == default)
+            {
+                timeout = TimeSpan.FromSeconds(5);
+            }
+
+            if (Debugger.IsAttached)
+            {
+                TimeSpan debuggingTimeout = TimeSpan.FromMinutes(5);
+                if (debuggingTimeout > timeout)
+                {
+                    timeout = debuggingTimeout;
+                }
+            }
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -1,0 +1,214 @@
+﻿namespace DurableTask.SqlServer.Tests.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.SqlServer.Tests.Logging;
+    using Microsoft.Extensions.Logging;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    class TestService
+    {
+        readonly SqlProviderOptions options;
+        readonly ILoggerFactory loggerFactory;
+
+        TaskHubWorker worker;
+        TaskHubClient client;
+
+        public TestService(ITestOutputHelper output)
+        {
+            Type type = output.GetType();
+            FieldInfo testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(output);
+
+            this.LogProvider = new TestLogProvider(output);
+            this.loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddProvider(this.LogProvider);
+            });
+
+            this.options = new SqlProviderOptions
+            {
+                AppName = test.DisplayName,
+                LoggerFactory = this.loggerFactory,
+            };
+        }
+
+        public TestLogProvider LogProvider { get; }
+
+        public async Task InitializeAsync()
+        {
+            var provider = new SqlOrchestrationService(this.options);
+            await ((IOrchestrationService)provider).CreateIfNotExistsAsync();
+
+            this.worker = await new TaskHubWorker(provider, this.loggerFactory).StartAsync();
+            this.client = new TaskHubClient(provider, loggerFactory: this.loggerFactory);
+        }
+
+        public Task PurgeAsync(DateTime minimumThreshold, OrchestrationStateTimeRangeFilterType filterType)
+        {
+            return this.client.PurgeOrchestrationInstanceHistoryAsync(
+                minimumThreshold,
+                filterType);
+        }
+
+        public async Task DisposeAsync()
+        {
+            await this.worker.StopAsync(isForced: true);
+            this.worker.Dispose();
+        }
+
+        public async Task<TestInstance<TInput>> RunOrchestration<TOutput, TInput>(
+            TInput input,
+            string orchestrationName,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null,
+            params (string name, TaskActivity activity)[] activities)
+        {
+            var instances = await this.RunOrchestrations(
+                count: 1,
+                inputGenerator: i => input,
+                orchestrationName,
+                implementation,
+                onEvent,
+                activities);
+
+            return instances.First();
+        }
+
+        public async Task<List<TestInstance<TInput>>> RunOrchestrations<TOutput, TInput>(
+            int count,
+            Func<int, TInput> inputGenerator,
+            string orchestrationName,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null,
+            params (string name, TaskActivity activity)[] activities)
+        {
+            // Register the inline orchestration - note that this will only work once per test
+            Type orchestrationType = typeof(OrchestrationShim<TOutput, TInput>);
+
+            this.worker.AddTaskOrchestrations(new TestObjectCreator<TaskOrchestration>(
+                orchestrationName,
+                MakeOrchestration(implementation, onEvent)));
+
+            foreach ((string name, TaskActivity activity) in activities)
+            {
+                this.worker.AddTaskActivities(new TestObjectCreator<TaskActivity>(name, activity));
+            }
+
+            DateTime utcNow = DateTime.UtcNow;
+
+            var instances = new List<TestInstance<TInput>>(count);
+            for (int i = 0; i < count; i++)
+            {
+                TInput input = inputGenerator(i);
+                OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(
+                    orchestrationName,
+                    string.Empty /* version */,
+                    input);
+
+                // Verify that the CreateOrchestrationInstanceAsync implementation set the InstanceID and ExecutionID fields
+                Assert.NotNull(instance.InstanceId);
+                Assert.NotNull(instance.ExecutionId);
+
+                instances.Add(new TestInstance<TInput>(this.client, instance, utcNow, input));
+            }
+
+            return instances;
+        }
+
+        public static TaskOrchestration MakeOrchestration<TOutput, TInput>(
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null)
+        {
+            return new OrchestrationShim<TOutput, TInput>(implementation, onEvent);
+        }
+
+        // This is just a wrapper around the constructor for convenience. It allows us to write 
+        // less code because generic arguments for methods can be implied, unlike constructors.
+        public static TaskActivity MakeActivity<TInput, TOutput>(
+            Func<TaskContext, TInput, TOutput> implementation)
+        {
+            return new ActivityShim<TInput, TOutput>(implementation);
+        }
+
+        static string GetFriendlyTypeName(Type type)
+        {
+            string friendlyName = type.Name;
+            if (type.IsGenericType)
+            {
+                int iBacktick = friendlyName.IndexOf('`');
+                if (iBacktick > 0)
+                {
+                    friendlyName = friendlyName.Remove(iBacktick);
+                }
+
+                friendlyName += "<";
+                Type[] typeParameters = type.GetGenericArguments();
+                for (int i = 0; i < typeParameters.Length; ++i)
+                {
+                    string typeParamName = GetFriendlyTypeName(typeParameters[i]);
+                    friendlyName += (i == 0 ? typeParamName : "," + typeParamName);
+                }
+
+                friendlyName += ">";
+            }
+
+            return friendlyName;
+        }
+
+        class ActivityShim<TInput, TOutput> : TaskActivity<TInput, TOutput>
+        {
+            public ActivityShim(Func<TaskContext, TInput, TOutput> implementation)
+            {
+                this.Implementation = implementation;
+            }
+
+            public Func<TaskContext, TInput, TOutput> Implementation { get; }
+
+            protected override TOutput Execute(TaskContext context, TInput input)
+            {
+                return this.Implementation(context, input);
+            }
+        }
+
+        class OrchestrationShim<TOutput, TInput> : TaskOrchestration<TOutput, TInput>
+        {
+            public OrchestrationShim(
+                Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+                Action<OrchestrationContext, string, string> onEvent = null)
+            {
+                this.Implementation = implementation;
+                this.OnEventRaised = onEvent;
+            }
+
+            public Func<OrchestrationContext, TInput, Task<TOutput>> Implementation { get; set; }
+
+            public Action<OrchestrationContext, string, string> OnEventRaised { get; set; }
+
+            public override Task<TOutput> RunTask(OrchestrationContext context, TInput input)
+                => this.Implementation(context, input);
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+                => this.OnEventRaised(context, name, input);
+        }
+
+        class TestObjectCreator<T> : ObjectCreator<T>
+        {
+            readonly T obj;
+
+            public TestObjectCreator(string name, T obj)
+            {
+                this.Name = name;
+                this.Version = string.Empty;
+                this.obj = obj;
+            }
+
+            public override T Create() => this.obj;
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -47,12 +47,14 @@
 
         public async Task InitializeAsync()
         {
+            // The initialization requires administrative credentials (default)
+            await new SqlOrchestrationService(this.options).CreateIfNotExistsAsync();
+
+            // The runtime will use low-privilege credentials
             string taskHubConnectionString = await this.CreateTaskHubLoginAsync();
             this.options.ConnectionString = taskHubConnectionString;
 
             var provider = new SqlOrchestrationService(this.options);
-            await ((IOrchestrationService)provider).CreateIfNotExistsAsync();
-
             this.worker = await new TaskHubWorker(provider, this.loggerFactory).StartAsync();
             this.client = new TaskHubClient(provider, loggerFactory: this.loggerFactory);
         }

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -4,9 +4,12 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Security.Cryptography;
+    using System.Text;
     using System.Threading.Tasks;
     using DurableTask.Core;
     using DurableTask.SqlServer.Tests.Logging;
+    using Microsoft.Data.SqlClient;
     using Microsoft.Extensions.Logging;
     using Xunit;
     using Xunit.Abstractions;
@@ -15,7 +18,9 @@
     {
         readonly SqlProviderOptions options;
         readonly ILoggerFactory loggerFactory;
+        readonly string testName;
 
+        string generatedUserId;
         TaskHubWorker worker;
         TaskHubClient client;
 
@@ -31,9 +36,9 @@
                 builder.AddProvider(this.LogProvider);
             });
 
+            this.testName = test.TestCase.TestMethod.Method.Name;
             this.options = new SqlProviderOptions
             {
-                AppName = test.DisplayName,
                 LoggerFactory = this.loggerFactory,
             };
         }
@@ -42,6 +47,9 @@
 
         public async Task InitializeAsync()
         {
+            string taskHubConnectionString = await this.CreateTaskHubLoginAsync();
+            this.options.ConnectionString = taskHubConnectionString;
+
             var provider = new SqlOrchestrationService(this.options);
             await ((IOrchestrationService)provider).CreateIfNotExistsAsync();
 
@@ -60,6 +68,8 @@
         {
             await this.worker.StopAsync(isForced: true);
             this.worker.Dispose();
+
+            await this.DropTaskHubLoginAsync();
         }
 
         public async Task<TestInstance<TInput>> RunOrchestration<TOutput, TInput>(
@@ -159,6 +169,96 @@
             }
 
             return friendlyName;
+        }
+
+        internal async Task<string> CreateTaskHubLoginAsync()
+        {
+            // NOTE: Max length for user IDs is 128 characters
+            string userId = $"{this.testName}_{DateTime.UtcNow:yyyyMMddhhmmssff}";
+            string password = GeneratePassword();
+
+            // Generate a low-priviledge user account. This will map to a unique task hub.
+            await ExecuteCommandAsync($"CREATE LOGIN [testlogin_{userId}] WITH PASSWORD = '{password}'");
+            await ExecuteCommandAsync($"CREATE USER [testuser_{userId}] FOR LOGIN [testlogin_{userId}]");
+            await ExecuteCommandAsync($"ALTER ROLE dt_runtime ADD MEMBER [testuser_{userId}]");
+
+            var existing = new SqlConnectionStringBuilder(this.options.ConnectionString);
+            var builder = new SqlConnectionStringBuilder()
+            {
+                UserID = $"testlogin_{userId}",
+                Password = password,
+                DataSource = existing.DataSource,
+                InitialCatalog = existing.InitialCatalog,
+            };
+
+            this.generatedUserId = userId;
+            return builder.ToString();
+        }
+
+        async Task DropTaskHubLoginAsync()
+        {
+            // Drop the generated user information
+            string userId = this.generatedUserId;
+            await ExecuteCommandAsync($"ALTER ROLE dt_runtime DROP MEMBER [testuser_{userId}]");
+            await ExecuteCommandAsync($"DROP USER IF EXISTS [testuser_{userId}]");
+
+            // drop all the connections; otherwise, the DROP LOGIN statement will fail
+            await ExecuteCommandAsync($"DECLARE @kill varchar(max) = ''; SELECT @kill = @kill + 'KILL ' + CAST(session_id AS varchar(5)) + ';' FROM sys.dm_exec_sessions WHERE original_login_name = 'testlogin_{userId}'; EXEC(@kill);");
+            await ExecuteCommandAsync($"DROP LOGIN [testlogin_{userId}]");
+        }
+
+        static async Task ExecuteCommandAsync(string commandText)
+        {
+            string connectionString = SqlProviderOptions.GetDefaultConnectionString();
+            await using SqlConnection connection = new SqlConnection(connectionString);
+            await using SqlCommand command = connection.CreateCommand();
+            await command.Connection.OpenAsync();
+
+            command.CommandText = commandText;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        static string GeneratePassword()
+        {
+            const string AllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHJKLMNPQRSTWXYZ0123456789#$";
+            const int PasswordLenth = 16;
+
+            string password = GetRandomString(AllowedChars, PasswordLenth);
+            while (!MeetsSqlPasswordConstraint(password))
+            {
+                password = GetRandomString(AllowedChars, PasswordLenth);
+            }
+
+            return password;
+        }
+
+        static string GetRandomString(string allowedChars, int length)
+        {
+            var result = new StringBuilder(length);
+            byte[] randomBytes = new byte[length * 4];
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                rng.GetBytes(randomBytes);
+
+                for (int i = 0; i < length; i++)
+                {
+                    int seed = BitConverter.ToInt32(randomBytes, i * 4);
+                    Random random = new Random(seed);
+                    result.Append(allowedChars[random.Next(allowedChars.Length)]);
+                }
+            }
+
+            return result.ToString();
+        }
+
+        static bool MeetsSqlPasswordConstraint(string password)
+        {
+            return !string.IsNullOrEmpty(password) &&
+                password.Any(c => char.IsUpper(c)) &&
+                password.Any(c => char.IsLower(c)) &&
+                password.Any(c => char.IsDigit(c)) &&
+                password.Any(c => !char.IsLetterOrDigit(c)) &&
+                password.Length >= 8;
         }
 
         class ActivityShim<TInput, TOutput> : TaskActivity<TInput, TOutput>

--- a/test/setup.ps1
+++ b/test/setup.ps1
@@ -4,7 +4,8 @@ param(
     [string]$tag="2019-latest",
     [int]$port=1433,
     [string]$dbname="DurableDB",
-    [string]$collation="Latin1_General_100_BIN2_UTF8"
+    [string]$collation="Latin1_General_100_BIN2_UTF8",
+    [string]$additinalRunFlags=""
 )
 
 Write-Host "Pulling down the mcr.microsoft.com/mssql/server:$tag image..."
@@ -12,11 +13,11 @@ docker pull mcr.microsoft.com/mssql/server:$tag
 
 # Start the SQL Server docker container with the specified edition
 Write-Host "Starting SQL Server $tag $sqlpid docker container on port $port" -ForegroundColor DarkYellow
-docker run --name mssql-server -e 'ACCEPT_EULA=Y' -e "SA_PASSWORD=$pw" -e "MSSQL_PID=$sqlpid" -p ${port}:1433 -d mcr.microsoft.com/mssql/server:$tag
+docker run $additinalRunFlags --name mssql-server -e 'ACCEPT_EULA=Y' -e "SA_PASSWORD=$pw" -e "MSSQL_PID=$sqlpid" -p ${port}:1433 -d mcr.microsoft.com/mssql/server:$tag
 
 # The container needs a bit more time before it can start accepting commands
-Write-Host "Sleeping for 10 seconds to let the container finish initializing..." -ForegroundColor Yellow
-Start-Sleep -Seconds 10
+Write-Host "Sleeping for 30 seconds to let the container finish initializing..." -ForegroundColor Yellow
+Start-Sleep -Seconds 30
 
 # Check to see what containers are running
 docker ps


### PR DESCRIPTION
Updates in this PR:
- Created new `dt_runtime` database role
- Updated orchestration tests to use multitenancy
- Updated README with multitenancy instructions and with local Windows install instructions
- Created new stored procedure, `dt.PurgeInstanceState`
- Implemented `IOrchestrationService.PurgeOrchestrationHistoryAsync`.
- Fixed a deadlock in `dt._CheckpointOrchestration` stored procedure that occurred when many instances completed at the same time.
- (Breaking) Renamed log event `CheckpointingOrchestration` to `CheckpointStarting` and changed its ID. Also created a new `CheckpointCompleted` event.
- Refactored tests to make shared logic more reusable
- Updated package versions to 0.3.0