### PR TITLE
Initial fault and duplicate execution handling logic

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -26,8 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.4.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
@@ -106,7 +106,7 @@
             SqlProviderOptions providerOptions = options.ProviderOptions;
             providerOptions.ConnectionString = connectionString;
             providerOptions.LoggerFactory = this.loggerFactory;
-            providerOptions.TaskEventLockTimeout = options.TaskEventLockTimeout;
+            providerOptions.WorkItemLockTimeout = options.TaskEventLockTimeout;
             return options;
         }
     }

--- a/src/DurableTask.SqlServer/LogHelper.cs
+++ b/src/DurableTask.SqlServer/LogHelper.cs
@@ -76,6 +76,15 @@
             this.WriteLog(logEvent);
         }
 
+        public void DuplicateExecutionDetected(OrchestrationInstance instance, string name)
+        {
+            var logEvent = new LogEvents.DuplicateExecutionDetected(
+                instance.InstanceId,
+                instance.ExecutionId,
+                name);
+            this.WriteLog(logEvent);
+        }
+
         void WriteLog(ILogEvent logEvent)
         {
             // LogDurableEvent is an extension method defined in DurableTask.Core

--- a/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
+++ b/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
@@ -154,5 +154,23 @@
                 AppName,
                 ExtensionVersion);
         }
+
+        [Event(EventIds.DuplicateExecutionDetected, Level = EventLevel.Warning)]
+        internal void DuplicateExecutionDetected(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            string AppName,
+            string ExtensionVersion)
+        {
+            // TODO: Use WriteEventCore for better performance
+            this.WriteEvent(
+                EventIds.DuplicateExecutionDetected,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                Name,
+                AppName,
+                ExtensionVersion);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/Logging/EventIds.cs
+++ b/src/DurableTask.SqlServer/Logging/EventIds.cs
@@ -13,5 +13,6 @@
         public const int GenericWarning = 304;
         public const int CheckpointStarting = 305;
         public const int CheckpointCompleted = 306;
+        public const int DuplicateExecutionDetected = 307;
     }
 }

--- a/src/DurableTask.SqlServer/Logging/LogEvents.cs
+++ b/src/DurableTask.SqlServer/Logging/LogEvents.cs
@@ -259,5 +259,44 @@
                     DTUtils.AppName,
                     DTUtils.ExtensionVersionString);
         }
+
+        internal class DuplicateExecutionDetected : StructuredLogEvent, IEventSourceEvent
+        {
+            public DuplicateExecutionDetected(
+                string instanceId,
+                string executionId,
+                string name)
+            {
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.Name = name;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DuplicateExecutionDetected,
+                nameof(EventIds.DuplicateExecutionDetected));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Duplicate execution of '{this.Name}' was detected! This means two workers or threads tried to process the same work item simultaneously. The result of this execution will be discarded.";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                DefaultEventSource.Log.DuplicateExecutionDetected(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    DTUtils.AppName,
+                    DTUtils.ExtensionVersionString);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -19,6 +19,7 @@ DROP PROCEDURE IF EXISTS dt._CompleteTasks
 DROP PROCEDURE IF EXISTS dt._GetVersions
 DROP PROCEDURE IF EXISTS dt._LockNextOrchestration
 DROP PROCEDURE IF EXISTS dt._LockNextTask
+DROP PROCEDURE IF EXISTS dt._RenewTaskLocks
 DROP PROCEDURE IF EXISTS dt._UpdateVersion
 
 -- Tables

--- a/src/DurableTask.SqlServer/SqlProviderOptions.cs
+++ b/src/DurableTask.SqlServer/SqlProviderOptions.cs
@@ -8,8 +8,8 @@
 
     public class SqlProviderOptions
     {
-        [JsonProperty("taskEventLockTimeout")]
-        public TimeSpan TaskEventLockTimeout { get; set; } = TimeSpan.FromMinutes(2);
+        [JsonProperty("workItemLockTimeout")]
+        public TimeSpan WorkItemLockTimeout { get; set; } = TimeSpan.FromMinutes(2);
 
         [JsonProperty("appName")]
         public string AppName { get; set; } = Environment.MachineName;

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -5,10 +5,12 @@
     using System.Data.Common;
     using System.Data.SqlTypes;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core;
     using DurableTask.Core.History;
+    using Microsoft.Data.SqlClient;
     using SemVersion;
 
     static class SqlUtils
@@ -329,6 +331,11 @@
                 latencyStopwatch.Stop();
                 traceHelper.SprocCompleted(command.CommandText, latencyStopwatch);
             }
+        }
+
+        public static bool IsUniqueKeyViolation(SqlException exception)
+        {
+            return exception.Errors.Cast<SqlError>().Any(e => e.Class == 14 && (e.Number == 2601 || e.Number == 2627));
         }
     }
 }

--- a/src/DurableTask.SqlServer/Utils/OrchestrationServiceBase.cs
+++ b/src/DurableTask.SqlServer/Utils/OrchestrationServiceBase.cs
@@ -49,7 +49,7 @@ namespace DurableTask.SqlServer.Utils
 
         public abstract Task DeleteAsync(bool deleteInstanceStore);
 
-        public abstract Task<TaskOrchestrationWorkItem> LockNextTaskOrchestrationWorkItemAsync(
+        public abstract Task<TaskOrchestrationWorkItem?> LockNextTaskOrchestrationWorkItemAsync(
             TimeSpan receiveTimeout,
             CancellationToken cancellationToken);
 
@@ -89,22 +89,12 @@ namespace DurableTask.SqlServer.Utils
 
         public virtual int GetDelayInSecondsAfterOnFetchException(Exception exception)
         {
-            if (exception is OperationCanceledException)
-            {
-                return 0;
-            }
-
-            throw new NotImplementedException();
+            return exception is OperationCanceledException ? 0 : 1;
         }
 
         public virtual int GetDelayInSecondsAfterOnProcessException(Exception exception)
         {
-            if (exception is OperationCanceledException)
-            {
-                return 0;
-            }
-
-            throw new NotImplementedException();
+            return exception is OperationCanceledException ? 0 : 1;
         }
 
         public virtual Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
+    <PackageReference Include="xunit" Version="2.4.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -9,10 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="3.1.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
+    <PackageReference Include="Moq" Version="4.15.*" />
+    <PackageReference Include="xunit" Version="2.4.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -222,6 +222,7 @@
                 "dt._GetVersions",
                 "dt._LockNextOrchestration",
                 "dt._LockNextTask",
+                "dt._RenewTaskLocks",
                 "dt._UpdateVersion",
             };
 

--- a/test/DurableTask.SqlServer.Tests/Integration/FaultTesting.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/FaultTesting.cs
@@ -1,0 +1,277 @@
+﻿namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.SqlServer.Tests.Logging;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Moq;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class FaultTesting : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public FaultTesting(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService?.DisposeAsync();
+
+        /// <summary>
+        /// Verifies that the orchestration correctly retries after a single faulted checkpoint.
+        /// </summary>
+        [Fact]
+        public async Task CheckpointOrchestrationFault()
+        {
+            // This test needs to wait for the lock timeout to expire after the injected fault
+            // before it will retry the checkpoint.
+            this.testService.OrchestrationServiceOptions.WorkItemLockTimeout = TimeSpan.FromSeconds(5);
+
+            // Set up a mock that will fail the first call, but succeed the second call
+            bool faultedOnce = false;
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.CompleteTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TaskOrchestrationWorkItem>(),
+                    It.IsAny<OrchestrationRuntimeState>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationState>()))
+                .Callback(() =>
+                {
+                    if (!faultedOnce)
+                    {
+                        faultedOnce = true;
+                        throw new Exception("Kah-BOOOOM!!!");
+                    }
+                });
+
+            // Does nothing except return the original input
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                input: "Hello, world!",
+                orchestrationName: "EmptyOrchestration",
+                implementation: (ctx, input) => Task.FromResult(input));
+
+            OrchestrationState state = await instance.WaitForCompletion();
+            Assert.Equal(OrchestrationStatus.Completed, state.OrchestrationStatus);
+            Assert.True(faultedOnce);
+
+            // Verify that the CompleteTaskOrchestrationWorkItemAsync method was called exactly twice
+            this.testService.OrchestrationServiceMock.Verify(svc => svc.CompleteTaskOrchestrationWorkItemAsync(
+                It.IsAny<TaskOrchestrationWorkItem>(),
+                It.IsAny<OrchestrationRuntimeState>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<TaskMessage>(),
+                It.IsAny<OrchestrationState>()), Times.Exactly(2));
+        }
+
+        /// <summary>
+        /// Verifies that when an orchestration hangs, the triggering event gets retried successfully,
+        /// and that the "unstuck" execution fails to checkpoint due to a detected duplicate execution.
+        /// </summary>
+        [Fact]
+        public async Task OrchestrationHang()
+        {
+            // This test needs to wait for the lock timeout to expire after the injected fault
+            // before it will retry the checkpoint.
+            this.testService.OrchestrationServiceOptions.WorkItemLockTimeout = TimeSpan.FromSeconds(5);
+
+            var resumeSignal = new ManualResetEvent(initialState: false);
+
+            // Set up a mock that will hang on the first call, but succeed the second call
+            bool firstCall = true;
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.CompleteTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TaskOrchestrationWorkItem>(),
+                    It.IsAny<OrchestrationRuntimeState>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<IList<TaskMessage>>(),
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationState>()))
+                .Callback(() =>
+                {
+                    if (firstCall)
+                    {
+                        firstCall = false;
+                        resumeSignal.WaitOne();
+                    }
+                });
+
+            // Block background work-item renewal to ensure another thread tries to execute the orchestration work item
+            this.testService.OrchestrationServiceMock
+                .Setup(svc => svc.ReleaseTaskOrchestrationWorkItemAsync(It.IsAny<TaskOrchestrationWorkItem>()))
+                .Callback(() => resumeSignal.WaitOne());
+
+            // Does nothing except return the original input
+            string orchestrationName = "EmptyOrchestration";
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                input: "Hello, world!",
+                orchestrationName,
+                implementation: (ctx, input) => Task.FromResult(input));
+
+            // Give the orchestration extra time to finish. Time is needed for the lock timeout
+            // to expire.
+            await instance.WaitForCompletion(TimeSpan.FromSeconds(30));
+
+            // Unblock the hung thread. This should result in a failure due to a detected duplicate execution.
+            resumeSignal.Set();
+
+            // Give the unblocked thread time to execute its logic and fail.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Verify that the CompleteTaskOrchestrationWorkItemAsync method was called exactly twice, and that the second call failed
+            this.testService.OrchestrationServiceMock.Verify(svc => svc.CompleteTaskOrchestrationWorkItemAsync(
+                It.IsAny<TaskOrchestrationWorkItem>(),
+                It.IsAny<OrchestrationRuntimeState>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<IList<TaskMessage>>(),
+                It.IsAny<TaskMessage>(),
+                It.IsAny<OrchestrationState>()), Times.Exactly(2));
+
+            // Check logs to confirm that a duplicate execution was detected
+            LogAssert.Sequence(
+                this.testService.LogProvider,
+                LogAssert.AcquiredAppLock(),
+                LogAssert.CheckpointStarting(orchestrationName),
+                LogAssert.CheckpointCompleted(orchestrationName),
+                LogAssert.CheckpointStarting(orchestrationName),
+                LogAssert.DuplicateExecutionDetected(orchestrationName));
+        }
+
+        /// <summary>
+        /// Verifies that when an activity task fails to checkpoint, the triggering event gets retried successfully.
+        /// </summary>
+        [Fact]
+        public async Task ActivityCheckpointFault()
+        {
+            // This test needs to wait for the lock timeout to expire after the injected fault
+            // before it will retry the checkpoint.
+            this.testService.OrchestrationServiceOptions.WorkItemLockTimeout = TimeSpan.FromSeconds(5);
+
+            // Set up a mock that will hang on the first call, but succeed the second call
+            bool firstCall = true;
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.CompleteTaskActivityWorkItemAsync(
+                    It.IsAny<TaskActivityWorkItem>(),
+                    It.IsAny<TaskMessage>()))
+                .Callback(() =>
+                {
+                    if (firstCall)
+                    {
+                        firstCall = false;
+                        throw new Exception("Kah-BOOOOM!!!");
+                    }
+                });
+
+            // Run an orchestration with a single activity function call
+            string orchestrationName = "OrchestrationWithActivity";
+            string input = $"[{DateTime.UtcNow:o}]";
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                input,
+                orchestrationName,
+                implementation: (ctx, input) => ctx.ScheduleTask<string>("SayHello", "", input),
+                activities: ("SayHello", TestService.MakeActivity((TaskContext ctx, string input) => $"Hello, {input}!")));
+
+            // Give the orchestration extra time to finish. Time is needed for the lock timeout
+            // to expire.
+            OrchestrationState state = await instance.WaitForCompletion(
+                timeout: TimeSpan.FromSeconds(30),
+                expectedOutput: $"Hello, {input}!");
+
+            Assert.False(firstCall);
+
+            // Verify that the CompleteTaskActivityWorkItemAsync method was called exactly twice, and that the second call failed
+            this.testService.OrchestrationServiceMock.Verify(
+                svc => svc.CompleteTaskActivityWorkItemAsync(
+                    It.IsAny<TaskActivityWorkItem>(),
+                    It.IsAny<TaskMessage>()),
+                Times.Exactly(2));
+        }
+
+
+        /// <summary>
+        /// Simulates a hang in task activity processing and verifies that the activity can be successfully resumed.
+        /// </summary>
+        [Fact]
+        public async Task ActivityHang()
+        {
+            // This test needs to wait for the lock timeout to expire after the injected fault
+            // before it will retry the checkpoint.
+            this.testService.OrchestrationServiceOptions.WorkItemLockTimeout = TimeSpan.FromSeconds(5);
+
+            var resumeSignal = new ManualResetEvent(initialState: false);
+
+            // Set up a mock that will hang on the first call, but succeed the second call
+            bool firstCall = true;
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.CompleteTaskActivityWorkItemAsync(
+                    It.IsAny<TaskActivityWorkItem>(),
+                    It.IsAny<TaskMessage>()))
+                .Callback(() =>
+                {
+                    if (firstCall)
+                    {
+                        firstCall = false;
+                        resumeSignal.WaitOne();
+                    }
+                });
+
+            // Block background activity renewal to ensure another thread tries to execute the activity work item
+            this.testService.OrchestrationServiceMock
+                .Setup(svc => svc.RenewTaskActivityWorkItemLockAsync(It.IsAny<TaskActivityWorkItem>()))
+                .Callback(() => resumeSignal.WaitOne());
+
+            // Run an orchestration with a single activity function call
+            string orchestrationName = "OrchestrationWithActivity";
+            string input = $"[{DateTime.UtcNow:o}]";
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                input,
+                orchestrationName,
+                implementation: (ctx, input) => ctx.ScheduleTask<string>("SayHello", "", input),
+                activities: ("SayHello", TestService.MakeActivity((TaskContext ctx, string input) => $"Hello, {input}!")));
+
+            // Give the orchestration extra time to finish. Time is needed for the lock timeout
+            // to expire.
+            OrchestrationState state = await instance.WaitForCompletion(
+                timeout: TimeSpan.FromSeconds(30),
+                expectedOutput: $"Hello, {input}!");
+
+            Assert.False(firstCall);
+
+            // Unblock the hung thread. This should result in a failure due to a detected duplicate execution.
+            resumeSignal.Set();
+
+            // Give the unblocked thread time to execute its logic and fail.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Verify that the CompleteTaskActivityWorkItemAsync method was called exactly twice, and that the second call failed
+            this.testService.OrchestrationServiceMock.Verify(
+                svc => svc.CompleteTaskActivityWorkItemAsync(
+                    It.IsAny<TaskActivityWorkItem>(),
+                    It.IsAny<TaskMessage>()),
+                Times.Exactly(2));
+
+            // Check logs to confirm that a duplicate execution was detected
+            LogAssert.Sequence(
+                this.testService.LogProvider,
+                LogAssert.AcquiredAppLock(),
+                LogAssert.CheckpointStarting(orchestrationName),
+                LogAssert.CheckpointCompleted(orchestrationName),
+                LogAssert.CheckpointStarting(orchestrationName),
+                LogAssert.CheckpointCompleted(orchestrationName),
+                LogAssert.DuplicateExecutionDetected("SayHello"));
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Integration/FaultTesting.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/FaultTesting.cs
@@ -141,9 +141,8 @@
                 It.IsAny<OrchestrationState>()), Times.Exactly(2));
 
             // Check logs to confirm that a duplicate execution was detected
-            LogAssert.Sequence(
+            LogAssert.Contains(
                 this.testService.LogProvider,
-                LogAssert.AcquiredAppLock(),
                 LogAssert.CheckpointStarting(orchestrationName),
                 LogAssert.CheckpointCompleted(orchestrationName),
                 LogAssert.CheckpointStarting(orchestrationName),
@@ -264,9 +263,8 @@
                 Times.Exactly(2));
 
             // Check logs to confirm that a duplicate execution was detected
-            LogAssert.Sequence(
+            LogAssert.Contains(
                 this.testService.LogProvider,
-                LogAssert.AcquiredAppLock(),
                 LogAssert.CheckpointStarting(orchestrationName),
                 LogAssert.CheckpointCompleted(orchestrationName),
                 LogAssert.CheckpointStarting(orchestrationName),

--- a/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
+++ b/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
@@ -55,6 +55,9 @@
         public static LogAssert CheckpointCompleted(string name) =>
             new LogAssert(306, "CheckpointCompleted", LogLevel.Information, name);
 
+        public static LogAssert DuplicateExecutionDetected(string name) =>
+            new LogAssert(307, "DuplicateExecutionDetected", LogLevel.Warning, name);
+
         public static void LogEntryCount(TestLogProvider logProvider, int expected) =>
             Assert.Equal(expected, GetLogs(logProvider).Count());
 
@@ -89,7 +92,7 @@
                 $"{asserts.Length} log entries were expected but only {actualLogs.Length} were found. Expected:{expected}Actual:{actual}");
         }
 
-        static void ValidateStructuredLogFields(LogEntry log)
+        internal static void ValidateStructuredLogFields(LogEntry log)
         {
             // All log entries are expected to have dictionary state
             var fields = log.State as IReadOnlyDictionary<string, object>;
@@ -121,6 +124,11 @@
                     Assert.True(fields.ContainsKey("InstanceId"));
                     Assert.True(fields.ContainsKey("ExecutionId"));
                     Assert.True(fields.ContainsKey("LatencyMs"));
+                    break;
+                case EventIds.DuplicateExecutionDetected:
+                    Assert.True(fields.ContainsKey("Name"));
+                    Assert.True(fields.ContainsKey("InstanceId"));
+                    Assert.True(fields.ContainsKey("ExecutionId"));
                     break;
                 default:
                     throw new ArgumentException($"Log event {log.EventId} is not known. Does it need to be added to the log validator?", nameof(log));

--- a/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
+++ b/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
@@ -92,6 +92,27 @@
                 $"{asserts.Length} log entries were expected but only {actualLogs.Length} were found. Expected:{expected}Actual:{actual}");
         }
 
+        public static void Contains(TestLogProvider logProvider, params LogAssert[] asserts)
+        {
+            var remaining = new HashSet<LogAssert>(asserts);
+
+            foreach (LogEntry logEntry in GetLogs(logProvider))
+            {
+                foreach (LogAssert assert in remaining.ToArray())
+                {
+                    if (string.Equals(assert.EventName, logEntry.EventId.Name) &&
+                        assert.EventId == logEntry.EventId.Id &&
+                        assert.Level == logEntry.LogLevel &&
+                        logEntry.Message.Contains(assert.MessageSubstring))
+                    {
+                        remaining.Remove(assert);
+                    }
+                }
+            }
+
+            Assert.Empty(remaining);
+        }
+
         internal static void ValidateStructuredLogFields(LogEntry log)
         {
             // All log entries are expected to have dictionary state

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -11,12 +11,12 @@
     using DurableTask.SqlServer.Tests.Logging;
     using Microsoft.Data.SqlClient;
     using Microsoft.Extensions.Logging;
+    using Moq;
     using Xunit;
     using Xunit.Abstractions;
 
     class TestService
     {
-        readonly SqlProviderOptions options;
         readonly ILoggerFactory loggerFactory;
         readonly string testName;
 
@@ -37,26 +37,30 @@
             });
 
             this.testName = test.TestCase.TestMethod.Method.Name;
-            this.options = new SqlProviderOptions
+            this.OrchestrationServiceOptions = new SqlProviderOptions
             {
                 LoggerFactory = this.loggerFactory,
             };
         }
+
+        public SqlProviderOptions OrchestrationServiceOptions { get; }
+
+        public Mock<SqlOrchestrationService> OrchestrationServiceMock { get; private set; }
 
         public TestLogProvider LogProvider { get; }
 
         public async Task InitializeAsync()
         {
             // The initialization requires administrative credentials (default)
-            await new SqlOrchestrationService(this.options).CreateIfNotExistsAsync();
+            await new SqlOrchestrationService(this.OrchestrationServiceOptions).CreateIfNotExistsAsync();
 
             // The runtime will use low-privilege credentials
             string taskHubConnectionString = await this.CreateTaskHubLoginAsync();
-            this.options.ConnectionString = taskHubConnectionString;
+            this.OrchestrationServiceOptions.ConnectionString = taskHubConnectionString;
 
-            var provider = new SqlOrchestrationService(this.options);
-            this.worker = await new TaskHubWorker(provider, this.loggerFactory).StartAsync();
-            this.client = new TaskHubClient(provider, loggerFactory: this.loggerFactory);
+            this.OrchestrationServiceMock = new Mock<SqlOrchestrationService>(this.OrchestrationServiceOptions) { CallBase = true };
+            this.worker = await new TaskHubWorker(this.OrchestrationServiceMock.Object, this.loggerFactory).StartAsync();
+            this.client = new TaskHubClient(this.OrchestrationServiceMock.Object, loggerFactory: this.loggerFactory);
         }
 
         public Task PurgeAsync(DateTime minimumThreshold, OrchestrationStateTimeRangeFilterType filterType)
@@ -173,6 +177,18 @@
             return friendlyName;
         }
 
+        public IEnumerable<LogEntry> GetAndValidateLogs()
+        {
+            if (this.LogProvider.TryGetLogs("DurableTask.SqlServer", out IReadOnlyCollection<LogEntry> logs))
+            {
+                foreach (LogEntry entry in logs)
+                {
+                    LogAssert.ValidateStructuredLogFields(entry);
+                    yield return entry;
+                }
+            }
+        }
+
         internal async Task<string> CreateTaskHubLoginAsync()
         {
             // NOTE: Max length for user IDs is 128 characters
@@ -184,7 +200,7 @@
             await ExecuteCommandAsync($"CREATE USER [testuser_{userId}] FOR LOGIN [testlogin_{userId}]");
             await ExecuteCommandAsync($"ALTER ROLE dt_runtime ADD MEMBER [testuser_{userId}]");
 
-            var existing = new SqlConnectionStringBuilder(this.options.ConnectionString);
+            var existing = new SqlConnectionStringBuilder(this.OrchestrationServiceOptions.ConnectionString);
             var builder = new SqlConnectionStringBuilder()
             {
                 UserID = $"testlogin_{userId}",

--- a/test/PerformanceTests/PerformanceTests.csproj
+++ b/test/PerformanceTests/PerformanceTests.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" version="2.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Implemented the following:
- abandon logic
- work item renewal (task activities)
- split brain handling
- tests for all the above

Additionally:
- fixed an ordering issue when fetching history
- updated nuget references